### PR TITLE
Add multi-turn conversation memory

### DIFF
--- a/src/api/rcli_api.cpp
+++ b/src/api/rcli_api.cpp
@@ -76,6 +76,9 @@ struct RCLIEngine {
 
     std::atomic<float> audio_rms{0.0f};
 
+    // Conversation memory (session-scoped, for multi-turn chat)
+    std::vector<std::pair<std::string, std::string>> conversation_history;
+
     std::mutex mutex;
     bool initialized = false;
 };
@@ -384,6 +387,56 @@ static std::string clean_llm_output(RCLIEngine* engine, const std::string& s) {
     return engine->pipeline.llm().profile().clean_output(s);
 }
 
+// Truncate conversation history to fit within a token budget.
+// Walks backward from most recent, keeping complete user/assistant pairs.
+static std::vector<std::pair<std::string, std::string>> truncate_history(
+    RCLIEngine* engine,
+    const std::vector<std::pair<std::string, std::string>>& history,
+    int token_budget)
+{
+    if (history.empty() || token_budget <= 0) return {};
+
+    std::vector<std::pair<std::string, std::string>> result;
+    int total_tokens = 0;
+
+    // Walk backward, keeping pairs (assistant then user going back)
+    for (int i = static_cast<int>(history.size()) - 1; i >= 0; i--) {
+        int entry_tokens = engine->pipeline.llm().count_tokens(
+            history[i].first + ": " + history[i].second);
+        if (total_tokens + entry_tokens > token_budget) break;
+        total_tokens += entry_tokens;
+        result.insert(result.begin(), history[i]);
+    }
+    return result;
+}
+
+// Compute trimmed history for a given user input and system prompt.
+static std::vector<std::pair<std::string, std::string>> get_trimmed_history(
+    RCLIEngine* engine,
+    const std::string& system_prompt,
+    const std::string& input)
+{
+    if (engine->conversation_history.empty()) return {};
+
+    int ctx_size = engine->pipeline.llm().context_size();
+    int system_tokens = engine->pipeline.llm().count_tokens(system_prompt);
+    int user_tokens = engine->pipeline.llm().count_tokens(input);
+    int history_budget = ctx_size - 512 - system_tokens - user_tokens - 50;
+
+    return truncate_history(engine, engine->conversation_history,
+                            std::max(0, history_budget));
+}
+
+// Cap conversation history to last N entries (must be even to keep pairs aligned)
+static void cap_history(std::vector<std::pair<std::string, std::string>>& history,
+                        size_t max_entries = 20)
+{
+    while (history.size() > max_entries) {
+        history.erase(history.begin());
+        if (!history.empty()) history.erase(history.begin());
+    }
+}
+
 // Helper: execute an action, fire callback, and summarize result via LLM
 static std::string execute_and_summarize(RCLIEngine* engine,
                                          const std::string& action_name,
@@ -560,6 +613,9 @@ const char* rcli_process_command(RCLIHandle handle, const char* text) {
             std::string args_json = needs_params
                 ? extract_params_via_llm(engine, *def, input) : std::string("{}");
             engine->last_response = execute_and_summarize(engine, matched_action, args_json, input);
+            engine->conversation_history.emplace_back("user", input);
+            engine->conversation_history.emplace_back("assistant", engine->last_response);
+            cap_history(engine->conversation_history);
             return engine->last_response.c_str();
         }
     }
@@ -571,19 +627,24 @@ const char* rcli_process_command(RCLIHandle handle, const char* text) {
     // tokens and ~80 ms of latency.  Everything else goes to the LLM (Tier 2)
     // which decides whether to call a tool or respond conversationally.
     if (match_score == 0 && input.size() < 40) {
+        const std::string conv_system =
+            "You are RCLI, a friendly on-device macOS voice assistant. "
+            "Keep responses brief, natural, and helpful. "
+            "Do NOT use <think> tags or tool calls.";
+        auto history = get_trimmed_history(engine, conv_system, input);
         auto gen_conversational = [&](const std::string& msg) {
             std::string raw = engine->pipeline.llm().generate(
                 engine->pipeline.llm().build_chat_prompt(
-                    "You are RCLI, a friendly on-device macOS voice assistant. "
-                    "Keep responses brief, natural, and helpful. "
-                    "Do NOT use <think> tags or tool calls.",
-                    {}, msg),
+                    conv_system, history, msg),
                 nullptr);
             return clean_llm_output(engine, raw);
         };
         engine->last_response = gen_conversational(input);
         if (engine->last_response.empty())
             engine->last_response = gen_conversational(input + " Answer directly.");
+        engine->conversation_history.emplace_back("user", input);
+        engine->conversation_history.emplace_back("assistant", engine->last_response);
+        cap_history(engine->conversation_history);
         return engine->last_response.c_str();
     }
 
@@ -600,8 +661,9 @@ const char* rcli_process_command(RCLIHandle handle, const char* text) {
             "chitchat), respond naturally WITHOUT calling any tool.\n"
             "4. Do NOT use <think> tags. Output ONLY the tool call or a brief response.\n";
 
+        auto history = get_trimmed_history(engine, system_prompt, input);
         std::string llm_output = engine->pipeline.llm().generate(
-            engine->pipeline.llm().build_chat_prompt(system_prompt, {}, input),
+            engine->pipeline.llm().build_chat_prompt(system_prompt, history, input),
             nullptr);
         llm_output = clean_llm_output(engine, llm_output);
 
@@ -629,6 +691,9 @@ const char* rcli_process_command(RCLIHandle handle, const char* text) {
             }
             if (any_valid && !combined_response.empty()) {
                 engine->last_response = combined_response;
+                engine->conversation_history.emplace_back("user", input);
+                engine->conversation_history.emplace_back("assistant", engine->last_response);
+                cap_history(engine->conversation_history);
                 return engine->last_response.c_str();
             }
 
@@ -644,7 +709,7 @@ const char* rcli_process_command(RCLIHandle handle, const char* text) {
                 engine->pipeline.llm().build_chat_prompt(
                     "You are RCLI, a friendly macOS voice assistant. "
                     "Keep responses brief and natural. Do NOT use <think> tags.",
-                    {}, input),
+                    history, input),
                 nullptr);
             engine->last_response = clean_llm_output(engine, engine->last_response);
         }
@@ -654,13 +719,23 @@ const char* rcli_process_command(RCLIHandle handle, const char* text) {
 
     // Retry once if output cleaned to empty (some models produce only think tokens)
     if (engine->last_response.empty()) {
+        auto retry_history = get_trimmed_history(engine,
+            "You are RCLI. Answer the user directly in one sentence. "
+            "Do NOT use <think> tags.", input);
         std::string retry = engine->pipeline.llm().generate(
             engine->pipeline.llm().build_chat_prompt(
                 "You are RCLI. Answer the user directly in one sentence. "
                 "Do NOT use <think> tags.",
-                {}, input + " Answer directly."),
+                retry_history, input + " Answer directly."),
             nullptr);
         engine->last_response = clean_llm_output(engine, retry);
+    }
+
+    // Record this turn in conversation history
+    if (!engine->last_response.empty()) {
+        engine->conversation_history.emplace_back("user", input);
+        engine->conversation_history.emplace_back("assistant", engine->last_response);
+        cap_history(engine->conversation_history);
     }
 
     return engine->last_response.c_str();
@@ -731,6 +806,13 @@ void rcli_stop_processing(RCLIHandle handle) {
     }
     rcli_stop_speaking(handle);
     rcli_stop_listening(handle);
+}
+
+void rcli_clear_history(RCLIHandle handle) {
+    if (!handle) return;
+    auto* engine = static_cast<RCLIEngine*>(handle);
+    std::lock_guard<std::mutex> lock(engine->mutex);
+    engine->conversation_history.clear();
 }
 
 const char* rcli_get_transcript(RCLIHandle handle) {

--- a/src/api/rcli_api.h
+++ b/src/api/rcli_api.h
@@ -77,6 +77,9 @@ int rcli_is_speaking(RCLIHandle handle);
 // Safe to call from any thread. Non-blocking.
 void rcli_stop_processing(RCLIHandle handle);
 
+// Clear conversation history (start a fresh conversation within the session)
+void rcli_clear_history(RCLIHandle handle);
+
 // Get the last transcript from STT
 const char* rcli_get_transcript(RCLIHandle handle);
 

--- a/src/engines/llm_engine.cpp
+++ b/src/engines/llm_engine.cpp
@@ -119,6 +119,11 @@ std::string LlmEngine::detokenize(const std::vector<int32_t>& tokens) {
     return result;
 }
 
+int LlmEngine::count_tokens(const std::string& text) {
+    if (!initialized_) return 0;
+    return static_cast<int>(tokenize(text, false).size());
+}
+
 std::string LlmEngine::generate(const std::string& prompt, TokenCallback on_token) {
     if (!initialized_) return "";
 

--- a/src/engines/llm_engine.h
+++ b/src/engines/llm_engine.h
@@ -103,6 +103,9 @@ public:
     std::string detokenize(const std::vector<int32_t>& tokens);
     std::string token_to_text(int32_t token);
 
+    // Count tokens in a string (for history budget management)
+    int count_tokens(const std::string& text);
+
     // Runtime config overrides for benchmarking
     void set_max_tokens(int n) { config_.max_tokens = n; }
     void set_ignore_eos(bool v) { config_.ignore_eos = v; }

--- a/src/pipeline/orchestrator.cpp
+++ b/src/pipeline/orchestrator.cpp
@@ -238,7 +238,7 @@ bool Orchestrator::run_file_pipeline(const std::string& input_wav, const std::st
             );
 
             // Clear KV cache for fresh second pass
-            llm_.clear_kv_cache();
+            //llm_.clear_kv_cache();
 
             // Second pass: generate WITH streaming to TTS
             SentenceDetector detector(queue_sentence, 3, 25, 7);
@@ -640,6 +640,7 @@ bool Orchestrator::run_stream_pipeline(const std::string& input_wav) {
 bool Orchestrator::start_live() {
     if (live_running_.load()) return false;
     live_running_.store(true, std::memory_order_release);
+    live_history_.clear();
 
     // Start audio
     audio_.start();
@@ -848,11 +849,32 @@ void Orchestrator::llm_thread_fn() {
         std::string response;
         bool use_tools = !tool_defs.empty() && tools_.needs_tools(user_text);
 
+        // Compute history budget for this turn
+        int ctx_size = llm_.context_size();
+        int system_tokens = llm_.count_tokens(config_.system_prompt);
+        int user_tokens = llm_.count_tokens(user_text);
+        int history_budget = ctx_size - 512 - system_tokens - user_tokens - 50;
+
+        // Truncate history to fit budget
+        std::vector<std::pair<std::string, std::string>> trimmed;
+        if (!live_history_.empty() && history_budget > 0) {
+            int total = 0;
+            for (int i = static_cast<int>(live_history_.size()) - 1; i >= 0; i--) {
+                int entry_tokens = llm_.count_tokens(
+                    live_history_[i].first + ": " + live_history_[i].second);
+                if (total + entry_tokens > history_budget) break;
+                total += entry_tokens;
+                trimmed.insert(trimmed.begin(), live_history_[i]);
+            }
+        }
+
         if (use_tools) {
-            // First pass: no TTS callback
-            response = llm_.generate_with_tools(
-                user_text, tool_defs, config_.system_prompt, nullptr
-            );
+            // First pass: build prompt with history, no TTS callback
+            std::string augmented_system = llm_.profile().build_tool_system_prompt(
+                config_.system_prompt, tool_defs);
+            std::string prompt = llm_.build_chat_prompt(augmented_system, trimmed, user_text);
+            prompt += llm_.profile().tool_call_start + "\n";
+            response = llm_.profile().tool_call_start + "\n" + llm_.generate(prompt, nullptr);
 
             auto tool_calls = tools_.parse_tool_calls(response);
 
@@ -887,15 +909,17 @@ void Orchestrator::llm_thread_fn() {
             // No tools path (knowledge query) — stream directly
             SentenceDetector detector(queue_sentence, 3, 25, 7);
 
-            if (llm_.has_prompt_cache()) {
+            if (llm_.has_prompt_cache() && trimmed.empty()) {
+                // First turn: use cached system prompt for speed
                 std::string user_portion =
                     "<|im_start|>user\n" + user_text + " /no_think<|im_end|>\n"
                     "<|im_start|>assistant\n";
                 response = llm_.generate_with_cached_prompt(user_portion,
                     [&](const TokenOutput& tok) { detector.feed(tok.text); });
             } else {
+                // Subsequent turns: full prompt with history
                 std::string prompt = llm_.build_chat_prompt(
-                    config_.system_prompt, {}, user_text
+                    config_.system_prompt, trimmed, user_text
                 );
                 response = llm_.generate(prompt, [&](const TokenOutput& tok) {
                     detector.feed(tok.text);
@@ -913,6 +937,18 @@ void Orchestrator::llm_thread_fn() {
         tts_worker.join();
 
         LOG_DEBUG("LLM", "Response: \"%s\"", response.c_str());
+
+        // Record turn in live conversation history
+        std::string clean_response = llm_.profile().clean_output(response);
+        if (!clean_response.empty()) {
+            live_history_.emplace_back("user", user_text);
+            live_history_.emplace_back("assistant", clean_response);
+            // Cap at 20 entries (10 turns)
+            while (live_history_.size() > 20) {
+                live_history_.erase(live_history_.begin());
+                if (!live_history_.empty()) live_history_.erase(live_history_.begin());
+            }
+        }
 
         // Wait for playback to finish, then go back to listening
         while (playback_rb_->available_read() > 0 &&

--- a/src/pipeline/orchestrator.h
+++ b/src/pipeline/orchestrator.h
@@ -101,6 +101,9 @@ public:
     using TranscriptCallback = std::function<void(const std::string& text, bool is_final)>;
     void set_transcript_callback(TranscriptCallback cb) { transcript_cb_ = std::move(cb); }
 
+    // Clear live conversation history
+    void clear_history() { live_history_.clear(); }
+
 private:
     void set_state(PipelineState new_state);
 
@@ -142,6 +145,9 @@ private:
     std::condition_variable text_cv_;
     std::string             pending_text_;
     bool                    text_ready_ = false;
+
+    // Conversation history for live mode (accessed only from llm_thread_fn)
+    std::vector<std::pair<std::string, std::string>> live_history_;
 };
 
 } // namespace rastack


### PR DESCRIPTION
## Summary
- LLM remembers previous exchanges within a session for natural follow-up questions
- Token-budget-aware history truncation to fit context window
- Works in TUI mode (API layer) and live/listen mode (Orchestrator)
- New `rcli_clear_history()` API for session reset
- KV cache still used on first turn; subsequent turns use full prompt with history

## Test plan
- [x] TUI: "My name is Aman" → "What's my name?" remembers correctly
- [x] Single-shot `ask` mode still works (no regression)
- [x] Build succeeds with zero errors