### PR TITLE
feat: engine-specific CLI launch commands

### DIFF
--- a/src/api/rcli_api.cpp
+++ b/src/api/rcli_api.cpp
@@ -47,6 +47,7 @@ struct RCLIEngine {
 
     // Config overrides from rcli_create() config_json
     std::string config_system_prompt;
+    std::string config_engine_override;  // "metalrt", "llamacpp", or "" (use preference file)
     int config_gpu_layers = -1;
     int config_ctx_size   = -1;
 
@@ -161,6 +162,8 @@ RCLIHandle rcli_create(const char* config_json) {
         if (!dir.empty()) engine->models_dir = dir;
         std::string prompt = config_get_string(cfg, "system_prompt");
         if (!prompt.empty()) engine->config_system_prompt = prompt;
+        std::string eng = config_get_string(cfg, "engine");
+        if (!eng.empty()) engine->config_engine_override = eng;
         engine->config_gpu_layers = config_get_int(cfg, "gpu_layers", -1);
         engine->config_ctx_size = config_get_int(cfg, "ctx_size", -1);
     }
@@ -331,9 +334,11 @@ int rcli_init(RCLIHandle handle, const char* models_dir, int gpu_layers) {
         rastack::RCLI_SYSTEM_PROMPT, engine->personality_key);
     LOG_DEBUG("RCLI", "Personality: %s", engine->personality_key.c_str());
 
-    // --- MetalRT (optional, based on user engine preference) ---
+    // --- MetalRT (optional, based on user engine preference or CLI override) ---
     {
-        std::string engine_pref = rcli::read_engine_preference();
+        std::string engine_pref = engine->config_engine_override.empty()
+            ? rcli::read_engine_preference()
+            : engine->config_engine_override;
         if (engine_pref == "metalrt" && !rastack::MetalRTLoader::gpu_supported()) {
             LOG_WARN("RCLI", "MetalRT requires Apple M3+ (Metal 3.1). Falling back to llama.cpp.");
             fprintf(stderr, "  MetalRT requires Apple M3 or later. Falling back to llama.cpp.\n");

--- a/src/cli/cli_common.h
+++ b/src/cli/cli_common.h
@@ -120,6 +120,7 @@ struct Args {
     int bench_runs = 3;
     int gpu_layers = 99;
     int ctx_size = 4096;
+    std::string engine_override;  // "metalrt" or "llamacpp" — set when command is an engine name
     bool no_speak = false;
     bool verbose = false;
     bool help = false;

--- a/src/cli/help.h
+++ b/src/cli/help.h
@@ -13,6 +13,8 @@ inline void print_usage(const char* argv0) {
         "    %s <command> [options]\n\n"
         "%s  COMMANDS%s\n"
         "    %s(no command)%s      Interactive mode (push-to-talk + text input)\n"
+        "    %smetalrt%s            Interactive mode using MetalRT engine\n"
+        "    %sllamacpp%s           Interactive mode using llama.cpp engine\n"
         "    %slisten%s             Voice mode — push-to-talk with SPACE\n"
         "    %sask%s <text>         One-shot text command\n"
         "    %sactions%s [name]     List all actions, or show detail for one\n"
@@ -38,6 +40,8 @@ inline void print_usage(const char* argv0) {
         "    --verbose, -v       Show debug logs from engines\n\n"
         "%s  EXAMPLES%s\n"
         "    rcli                                    # interactive mode\n"
+        "    rcli metalrt                            # interactive mode (MetalRT)\n"
+        "    rcli llamacpp                           # interactive mode (llama.cpp)\n"
         "    rcli listen                             # hands-free voice control\n"
         "    rcli ask \"open Safari\"                  # one-shot command\n"
         "    rcli ask \"create a note called Ideas\"   # triggers action\n"
@@ -48,6 +52,8 @@ inline void print_usage(const char* argv0) {
         color::bold, color::reset,
         argv0,
         color::bold, color::reset,
+        color::green, color::reset,
+        color::green, color::reset,
         color::green, color::reset,
         color::green, color::reset,
         color::green, color::reset,

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -79,7 +79,14 @@ static int cmd_interactive(const Args& args) {
     fprintf(stderr, "\n  %sLoading AI models...%s ", color::dim, color::reset);
     fflush(stderr);
 
-    g_engine = rcli_create(nullptr);
+    // Pass engine override via config JSON if specified (e.g. "rcli metalrt", "rcli llamacpp")
+    const char* config_json = nullptr;
+    std::string config_buf;
+    if (!args.engine_override.empty()) {
+        config_buf = "{\"engine\": \"" + args.engine_override + "\"}";
+        config_json = config_buf.c_str();
+    }
+    g_engine = rcli_create(config_json);
     if (!g_engine) {
         fprintf(stderr, "\n  %s%sError: Failed to create engine%s\n", color::bold, color::red, color::reset);
         return 1;
@@ -1080,7 +1087,24 @@ int main(int argc, char** argv) {
     if (args.command == "cleanup")     return cmd_cleanup(args);
     if (args.command == "bench")       return cmd_bench(args);
     if (args.command == "info")        return cmd_info();
-    if (args.command == "metalrt")     return cmd_metalrt(args);
+    if (args.command == "metalrt") {
+        // Subcommands: install, remove, status, download, bench → management
+        if (!args.arg1.empty() && (args.arg1 == "install" || args.arg1 == "remove" ||
+            args.arg1 == "status" || args.arg1 == "download" || args.arg1 == "bench"))
+            return cmd_metalrt(args);
+        // Bare "rcli metalrt" → launch interactive TUI with MetalRT engine
+        Args override_args = args;
+        override_args.engine_override = "metalrt";
+        override_args.command.clear();
+        return cmd_interactive(override_args);
+    }
+    if (args.command == "llamacpp") {
+        // "rcli llamacpp" → launch interactive TUI with llama.cpp engine
+        Args override_args = args;
+        override_args.engine_override = "llamacpp";
+        override_args.command.clear();
+        return cmd_interactive(override_args);
+    }
     if (args.command == "engine")      return cmd_engine(args);
     if (args.command == "personality") return cmd_personality(args);
 

--- a/src/cli/tui_app.h
+++ b/src/cli/tui_app.h
@@ -271,19 +271,6 @@ public:
                 if (event == Event::Return) { models_select_or_download(); return true; }
                 return true;
             }
-            if (engine_mode_) {
-                if (event == Event::Escape) { engine_mode_ = false; return true; }
-                if (event == Event::ArrowUp) {
-                    if (engine_cursor_ > 0) engine_cursor_--;
-                    return true;
-                }
-                if (event == Event::ArrowDown) {
-                    if (engine_cursor_ < (int)engine_entries_.size() - 1) engine_cursor_++;
-                    return true;
-                }
-                if (event == Event::Return) { engine_select(); return true; }
-                return true;
-            }
             if (personality_mode_) {
                 if (event == Event::Escape) { personality_mode_ = false; return true; }
                 if (event == Event::ArrowUp) {
@@ -438,7 +425,6 @@ public:
                 if (c == "b" || c == "B") { enter_bench_mode(); return true; }
                 if (c == "r" || c == "R") { enter_rag_mode(); return true; }
                 if (c == "d" || c == "D") { close_all_panels(); enter_cleanup_mode(); return true; }
-                if (c == "e" || c == "E") { enter_engine_switcher(); return true; }
                 if (c == "p" || c == "P") { enter_personality_mode(); return true; }
                 // V key: voice mode removed — push-to-talk via SPACE is always active
                 if (c == "t" || c == "T") {
@@ -763,8 +749,6 @@ private:
 
         if (cleanup_mode_)
             layout.push_back(build_cleanup_panel() | flex);
-        else if (engine_mode_)
-            layout.push_back(build_engine_panel() | flex);
         else if (personality_mode_)
             layout.push_back(build_personality_panel() | flex);
         else if (models_mode_)
@@ -1346,150 +1330,7 @@ private:
         actions_mode_ = false;
         bench_mode_ = false;
         rag_mode_ = false;
-        engine_mode_ = false;
         personality_mode_ = false;
-    }
-
-    // ====================================================================
-    // [E] Engine panel — select llama.cpp / MetalRT
-    // ====================================================================
-
-    void enter_engine_switcher() {
-        close_all_panels();
-        engine_entries_.clear();
-        engine_cursor_ = 0;
-        engine_message_.clear();
-
-        std::string current = rcli::read_engine_preference();
-        if (current.empty()) current = "auto";
-
-        bool metalrt_gpu_ok = rastack::MetalRTLoader::gpu_supported();
-        bool metalrt_available = false;
-        if (metalrt_gpu_ok) {
-            std::string dylib_path = rastack::MetalRTLoader::engines_dir() + "/libmetalrt.dylib";
-            struct stat st;
-            metalrt_available = (stat(dylib_path.c_str(), &st) == 0);
-        }
-
-        engine_entries_.push_back({"llamacpp",
-            "llama.cpp",
-            "CPU inference \u00B7 GGUF models \u00B7 Universal compatibility",
-            current == "llamacpp"});
-
-        std::string mrt_desc = metalrt_gpu_ok
-            ? (std::string("GPU-accelerated \u00B7 MLX 4-bit \u00B7 Apple Silicon optimized") +
-               (metalrt_available ? "" : "  [not installed]"))
-            : "Requires Apple M3 or later";
-        engine_entries_.push_back({"metalrt",
-            "MetalRT",
-            mrt_desc,
-            current == "metalrt"});
-
-        if (current == "auto") {
-            for (auto& e : engine_entries_)
-                if (e.id == "metalrt" && metalrt_available) e.is_active = true;
-                else if (e.id == "llamacpp" && !metalrt_available) e.is_active = true;
-        }
-
-        engine_mode_ = true;
-    }
-
-    void engine_select() {
-        if (engine_cursor_ < 0 || engine_cursor_ >= (int)engine_entries_.size()) return;
-        auto& sel = engine_entries_[engine_cursor_];
-
-        if (sel.is_active) {
-            engine_message_ = sel.name + " is already active.";
-            engine_msg_color_ = ftxui::Color::Yellow;
-            return;
-        }
-
-        if (sel.id == "metalrt") {
-            if (!rastack::MetalRTLoader::gpu_supported()) {
-                engine_message_ = "MetalRT requires Apple M3 or later. Use llama.cpp instead.";
-                engine_msg_color_ = ftxui::Color::Red;
-                return;
-            }
-            std::string dylib_path = rastack::MetalRTLoader::engines_dir() + "/libmetalrt.dylib";
-            struct stat st;
-            if (stat(dylib_path.c_str(), &st) != 0) {
-                engine_message_ = "Installing MetalRT engine...";
-                engine_msg_color_ = ftxui::Color::Yellow;
-                screen_->PostEvent(ftxui::Event::Custom);
-
-                std::thread([this]() {
-                    bool ok = rastack::MetalRTLoader::install();
-                    if (!ok) {
-                        engine_message_ = "MetalRT install failed. Check internet and try: rcli metalrt install";
-                        engine_msg_color_ = ftxui::Color::Red;
-                        screen_->PostEvent(ftxui::Event::Custom);
-                        return;
-                    }
-                    engine_message_ = "MetalRT installed! Downloading default models...";
-                    engine_msg_color_ = ftxui::Color::Yellow;
-                    screen_->PostEvent(ftxui::Event::Custom);
-
-                    auto models = rcli::all_models();
-                    for (auto& m : models) {
-                        if (m.metalrt_id == "metalrt-lfm2.5-1.2b" && !rcli::is_metalrt_model_installed(m)) {
-                            std::string mrt_dir = rcli::metalrt_models_dir() + "/" + m.metalrt_dir_name;
-                            std::string cfg_url = m.metalrt_url;
-                            auto pos = cfg_url.rfind("model.safetensors");
-                            if (pos != std::string::npos) cfg_url.replace(pos, 17, "config.json");
-                            std::string dl = "bash -c 'set -e; mkdir -p \"" + mrt_dir + "\"; "
-                                "curl -fL -s -o \"" + mrt_dir + "/model.safetensors\" \"" + m.metalrt_url + "\"; "
-                                "curl -fL -s -o \"" + mrt_dir + "/tokenizer.json\" \"" + m.metalrt_tokenizer_url + "\"; "
-                                "curl -fL -s -o \"" + mrt_dir + "/config.json\" \"" + cfg_url + "\"; '";
-                            system(dl.c_str());
-                            break;
-                        }
-                    }
-                    auto comps = rcli::metalrt_component_models();
-                    for (auto& cm : comps) {
-                        if (!cm.default_install || rcli::is_metalrt_component_installed(cm)) continue;
-                        std::string cm_dir = rcli::metalrt_models_dir() + "/" + cm.dir_name;
-                        std::string hf = "https://huggingface.co/" + cm.hf_repo + "/resolve/main/";
-                        std::string sub = cm.hf_subdir.empty() ? "" : cm.hf_subdir + "/";
-                        if (cm.component == "tts") {
-                            std::string dl = "bash -c 'set -e; mkdir -p \"" + cm_dir + "/voices\"; "
-                                "curl -fL -s -o \"" + cm_dir + "/config.json\" \"" + hf + sub + "config.json\"; "
-                                "curl -fL -s -o \"" + cm_dir + "/kokoro-v1_0.safetensors\" \"" + hf + sub + "kokoro-v1_0.safetensors\"; "
-                                "for v in af_heart af_alloy af_aoede af_bella af_jessica af_kore af_nicole af_nova af_river af_sarah af_sky "
-                                "am_adam am_echo am_eric am_fenrir am_liam am_michael am_onyx am_puck am_santa "
-                                "bf_alice bf_emma bf_isabella bf_lily bm_daniel bm_fable bm_george bm_lewis; do "
-                                "curl -fL -s -o \"" + cm_dir + "/voices/${v}.safetensors\" \"" + hf + sub + "voices/${v}.safetensors\"; done; '";
-                            system(dl.c_str());
-                        } else {
-                            std::string dl = "bash -c 'set -e; mkdir -p \"" + cm_dir + "\"; "
-                                "curl -fL -s -o \"" + cm_dir + "/config.json\" \"" + hf + sub + "config.json\"; "
-                                "curl -fL -s -o \"" + cm_dir + "/model.safetensors\" \"" + hf + sub + "model.safetensors\"; "
-                                "curl -fL -s -o \"" + cm_dir + "/tokenizer.json\" \"" + hf + sub + "tokenizer.json\"; '";
-                            system(dl.c_str());
-                        }
-                    }
-
-                    rcli::write_engine_preference("metalrt");
-                    for (auto& e : engine_entries_) e.is_active = (e.id == "metalrt");
-                    engine_message_ = "MetalRT installed & ready! Restart RCLI to activate.";
-                    engine_msg_color_ = ftxui::Color::Green;
-                    screen_->PostEvent(ftxui::Event::Custom);
-                }).detach();
-                return;
-            }
-        }
-
-        rcli::write_engine_preference(sel.id);
-
-        for (auto& e : engine_entries_) e.is_active = false;
-        sel.is_active = true;
-
-        if (sel.id == "metalrt") {
-            engine_message_ = "MetalRT Engine selected. Restart to apply.";
-            engine_msg_color_ = theme_.info;
-        } else {
-            engine_message_ = "Switched to llama.cpp. Restart to apply.";
-            engine_msg_color_ = ftxui::Color::Green;
-        }
     }
 
     // ====================================================================
@@ -1990,69 +1831,6 @@ private:
                 screen_->Post(Event::Custom);
             }).detach();
         }
-    }
-
-    Element build_engine_panel() {
-        Elements rows;
-        rows.push_back(text("  \u2501\u2501\u2501 Engine Selection \u2501\u2501\u2501") | ftxui::bold | ftxui::color(theme_.accent));
-        rows.push_back(text("  Choose inference backend. Restart RCLI after switching.") | dim);
-        rows.push_back(text(""));
-
-        for (int i = 0; i < (int)engine_entries_.size(); i++) {
-            auto& e = engine_entries_[i];
-            bool selected = (i == engine_cursor_);
-            bool is_mrt = (e.id == "metalrt");
-
-            std::string cursor = selected ? " \u25B6 " : "   ";
-            std::string active_tag = e.is_active ? "  [active]" : "";
-
-            Element name_el;
-            if (is_mrt) {
-                name_el = hbox({
-                    text(cursor),
-                    text(e.name) | ftxui::bold | ftxui::color(theme_.info),
-                    text(active_tag) | ftxui::bold | ftxui::color(theme_.success),
-                });
-            } else {
-                name_el = text(cursor + e.name + active_tag);
-            }
-
-            if (selected) {
-                if (!is_mrt) name_el = name_el | ftxui::bold | ftxui::color(theme_.accent);
-                name_el = name_el | inverted;
-            } else if (e.is_active && !is_mrt) {
-                name_el = name_el | ftxui::color(theme_.success);
-            }
-
-            auto desc_el = text("     " + e.description) | dim;
-
-            rows.push_back(name_el);
-            rows.push_back(desc_el);
-
-            if (is_mrt) {
-                rows.push_back(
-                    text("     Fastest inference on Apple Silicon \u00B7 Sub-100ms TTFT")
-                    | ftxui::bold | ftxui::color(theme_.success));
-            } else {
-                rows.push_back(
-                    text("     Good for: Maximum model compatibility")
-                    | dim);
-            }
-
-            if (i < (int)engine_entries_.size() - 1)
-                rows.push_back(text(""));
-        }
-
-        rows.push_back(text(""));
-        rows.push_back(text("  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500") | dim);
-        rows.push_back(text("  [Enter] Select  [Esc] Back") | dim);
-
-        if (!engine_message_.empty()) {
-            rows.push_back(text(""));
-            rows.push_back(text("  " + engine_message_) | ftxui::color(engine_msg_color_));
-        }
-
-        return vbox(std::move(rows));
     }
 
     Element build_personality_panel() {
@@ -2654,7 +2432,6 @@ private:
             add_system_message("  X      Clear conversation + reset context");
             add_system_message("  Q      Quit");
             add_system_message("--- Panels ---");
-            add_system_message("  E      Switch inference engine");
             add_system_message("  M      Models (browse / switch / download)");
             add_system_message("  A      Actions (browse / run macOS actions)");
             add_system_message("  B      Benchmarks");
@@ -3035,14 +2812,6 @@ private:
     std::vector<ActionEntry> actions_entries_;
     std::string actions_message_;
     ftxui::Color actions_msg_color_ = theme_.warning;
-
-    // Engine panel state
-    bool engine_mode_ = false;
-    int engine_cursor_ = 0;
-    struct EngineEntry { std::string id, name, description; bool is_active = false; };
-    std::vector<EngineEntry> engine_entries_;
-    std::string engine_message_;
-    ftxui::Color engine_msg_color_;
 
     // Voice mode state
     bool voice_mode_active_ = false;


### PR DESCRIPTION
## Summary
- Add `rcli metalrt` and `rcli llamacpp` as top-level commands that launch the interactive TUI with the specified engine forced for that session (without changing the persistent `~/.rcli/engine_preference`)
- `rcli metalrt install/remove/status/download/bench` management subcommands continue to work as before
- Remove the in-TUI engine switcher panel (`E` keybinding) — engine selection is now done at launch time via CLI
- Add `engine` override support to `rcli_create()` config JSON and `rcli_init()` initialization flow

## Test plan
- [ ] `rcli --help` shows `metalrt` and `llamacpp` in commands list
- [ ] `rcli metalrt` launches TUI with MetalRT engine
- [ ] `rcli llamacpp` launches TUI with llama.cpp engine
- [ ] `rcli metalrt install` still works (management subcommand)
- [ ] `rcli engine metalrt` still sets persistent preference
- [ ] `E` key no longer opens engine panel in TUI
- [ ] Engine badge in TUI status bar still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)